### PR TITLE
Styling Fixes

### DIFF
--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -67,10 +67,12 @@ class WebRTCCamera extends HTMLElement {
             video.muted = true;
             video.playsInline = true;
             video.style.width = '100%';
+            video.style.display = 'block';
             video.srcObject = this.stream;
 
             const card = document.createElement('ha-card');
             // card.header = 'WebRTC Card';
+            card.style.overflow = 'hidden';
             card.appendChild(video);
             this.appendChild(card);
 


### PR DESCRIPTION
Removes extra 5px of space below video element. video elements default to display: inline causing the whitespace
Adds card overflow: hidden to support rounder corners.