### PR TITLE
Add Video Poster Support

### DIFF
--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -82,6 +82,7 @@ class WebRTCCamera extends HTMLElement {
             video.controls = true;
             video.muted = true;
             video.playsInline = true;
+            video.poster = this.config.poster || '';
             video.style.width = '100%';
             video.style.display = 'block';
             video.srcObject = this.stream;


### PR DESCRIPTION
allows setting video poster attribute to display a still image when stream is loading.