### PR TITLE
Bugfix/clean up after dom remove

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ poster: https://home-assistant.io/images/cast/splash.png  # still image when str
 intersection: 0.75  # auto pause stream when less than 75% of video element is in the screen, 50% by default
 muted: false  # disable sound, default true
 ui: true  # custom video controls, default false
+should_run_in_background: true # makes the component run when not displayed (ex. for quick video loading), default false
 
 ptz:  # check full examples in wiki
 

--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -50,6 +50,7 @@ class WebRTCCamera extends HTMLElement {
                 await pc.setLocalDescription(offer);
                 this.subscriptions.push(() => {
                     pc.close();
+                    pc = null;
                     console.debug("Closing RTCPeerConnection");
                 });
             }

--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -632,7 +632,7 @@ class WebRTCCamera extends HTMLElement {
             this.rendered = true;
         }
 
-        if ([this.ws.CLOSING, this.ws.CLOSED].includes(this.ws.readyState)) {
+        if (!this.ws || [this.ws.CLOSING, this.ws.CLOSED].includes(this.ws.readyState)) {
             await this.initMSE(this.hass);
         }
     }

--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -632,7 +632,7 @@ class WebRTCCamera extends HTMLElement {
             this.rendered = true;
         }
 
-        if (!this.ws) {
+        if ([this.ws.CLOSING, this.ws.CLOSED].includes(this.ws.readyState)) {
             await this.initMSE(this.hass);
         }
     }

--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -92,7 +92,7 @@ class WebRTCCamera extends HTMLElement {
             console.debug(`Reconnect in ${delay} ms`);
 
             setTimeout(() => {
-                if (!this.isConnected) {
+                if (this.isConnected) {
                     this.status = "Restart connection";
                     this.initMSE(hass, pc);
                 }
@@ -175,8 +175,10 @@ class WebRTCCamera extends HTMLElement {
                     const offer = await pc.createOffer({iceRestart: true})
                     await pc.setLocalDescription(offer);
                 } else {
-                    video.src = '';
-                    this.initMSE(hass, pc);
+                    if (this.isConnected) {
+                        video.src = '';
+                        this.initMSE(hass, pc);
+                    }
                 }
             } else if (pc.connectionState === 'connected') {
                 this.readyState = 'webrtc-loading';

--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -577,11 +577,6 @@ class WebRTCCamera extends HTMLElement {
         }
     }
 
-    set hass(hass) {
-        if (this.firstChild || typeof this.config === 'undefined') return;
-        this.hass = hass;
-    }
-
     setPTZVisibility(show) {
         const ptz = this.querySelector('.ptz');
         if (ptz) {
@@ -621,6 +616,7 @@ class WebRTCCamera extends HTMLElement {
     }
 
     async connectedCallback() {
+        if (this.firstChild || typeof this.config === 'undefined') return;
         await this.renderGUI(hass);
         await this.initMSE(hass);
     }

--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -23,7 +23,7 @@ class WebRTCCamera extends HTMLElement {
         this.subscriptions.push(() => {
             this.ws.onclose = null;
             this.ws.close();
-            this.ws = null;
+            console.debug("Closing websocket");
         });
 
         ws.onopen = async () => {
@@ -48,7 +48,10 @@ class WebRTCCamera extends HTMLElement {
 
                 const offer = await pc.createOffer({iceRestart: true})
                 await pc.setLocalDescription(offer);
-                this.subscriptions.push(() => pc.close());
+                this.subscriptions.push(() => {
+                    pc.close();
+                    console.debug("Closing RTCPeerConnection");
+                });
             }
         }
         ws.onmessage = ev => {

--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -639,9 +639,9 @@ class WebRTCCamera extends HTMLElement {
             visibilityChange = "webkitvisibilitychange";
         }
 
-        document.addEventListener(visibilityChange, async () => {
+        document.addEventListener(visibilityChange, () => {
             if (!document[hidden] && this.isConnected) {
-                await this.connectedCallback();
+                this.connectedCallback();
             } else {
                 this.disconnectedCallback();
             }

--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -618,7 +618,7 @@ class WebRTCCamera extends HTMLElement {
     }
 
     async connectedCallback() {
-        if (this.firstChild || typeof this.config === 'undefined') return;
+        if (typeof this.config === 'undefined') return;
         await this.renderGUI(this.hass);
         await this.initMSE(this.hass);
     }

--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -617,8 +617,8 @@ class WebRTCCamera extends HTMLElement {
 
     async connectedCallback() {
         if (this.firstChild || typeof this.config === 'undefined') return;
-        await this.renderGUI(hass);
-        await this.initMSE(hass);
+        await this.renderGUI(this.hass);
+        await this.initMSE(this.hass);
     }
 
     disconnectedCallback(){

--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -626,7 +626,7 @@ class WebRTCCamera extends HTMLElement {
             this.rendered = true;
         }
 
-        if (!this.ws || this.ws.CLOSED || this.ws.CLOSING) {
+        if (!this.ws || this.readyState === this.ws.CLOSED || this.readyState === this.ws.CLOSING) {
             await this.initMSE(this.hass);
         }
     }

--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -579,10 +579,7 @@ class WebRTCCamera extends HTMLElement {
 
     set hass(hass) {
         if (this.firstChild || typeof this.config === 'undefined') return;
-
-        this.renderGUI(hass).then(async () => {
-            await this.initMSE(hass);
-        });
+        this.hass = hass;
     }
 
     setPTZVisibility(show) {
@@ -621,6 +618,11 @@ class WebRTCCamera extends HTMLElement {
         return {
             url: 'rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mov'
         }
+    }
+
+    async connectedCallback() {
+        await this.renderGUI(hass);
+        await this.initMSE(hass);
     }
 
     disconnectedCallback(){

--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -1,7 +1,5 @@
 class WebRTCCamera extends HTMLElement {
-    constructor() {
-        this.subscriptions = [];
-    }
+    subscriptions = [];
 
     async initMSE(hass, pc = null) {
         const ts = Date.now();

--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -513,6 +513,8 @@ class WebRTCCamera extends HTMLElement {
             video.play().then(() => null, () => null);
         });
 
+        this.initPageVisibilityListener();
+
         const observer = new IntersectionObserver(
             (entries) => {
                 entries.forEach((entry) => {
@@ -622,6 +624,28 @@ class WebRTCCamera extends HTMLElement {
         return {
             url: 'rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mov'
         }
+    }
+
+    initPageVisibilityListener() {
+        var hidden, visibilityChange;
+        if (typeof document.hidden !== "undefined") { // Opera 12.10 and Firefox 18 and later support
+            hidden = "hidden";
+            visibilityChange = "visibilitychange";
+        } else if (typeof document.msHidden !== "undefined") {
+            hidden = "msHidden";
+            visibilityChange = "msvisibilitychange";
+        } else if (typeof document.webkitHidden !== "undefined") {
+            hidden = "webkitHidden";
+            visibilityChange = "webkitvisibilitychange";
+        }
+
+        document.addEventListener(visibilityChange, async () => {
+            if (!document[hidden] && this.isConnected) {
+                await this.connectedCallback();
+            } else {
+                this.disconnectedCallback();
+            }
+        }, false);
     }
 
     async connectedCallback() {

--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -631,6 +631,8 @@ class WebRTCCamera extends HTMLElement {
             await this.renderGUI(this.hass);
             this.rendered = true;
         }
+        
+        if (this.ws && this.config.should_run_in_background === true) return;
 
         if (!this.ws || [this.ws.CLOSING, this.ws.CLOSED].includes(this.ws.readyState)) {
             await this.initMSE(this.hass);


### PR DESCRIPTION
I noticed that when I switch between tabs in the lovelace the WebRTC connection remains connected in the background.
So each time you switch between tabs it creates a new connection that can result in a high CPU and a slow client (Fixed in this branch - prevented multiple connection for the same stream to be created).
I added a config called `should_run_in_background` in case someone wants the connection to stay open even when you are in a different tab.