### PR TITLE
index: Fix URL parameter parsing

### DIFF
--- a/custom_components/webrtc/www/index.html
+++ b/custom_components/webrtc/www/index.html
@@ -19,7 +19,7 @@
 </head>
 <body>
 <script>
-    const url = document.referrer ? new URL(document.referrer) : window.location;
+    const url = window.location;
 
     const hass = {}
     hass.callWS = () => '';


### PR DESCRIPTION
When using DashCast or any other external site that may use the embedded
URL, we want to make sure we are using the original location of the page
instead of looking at the referrer URL. The referrer URL will not have
the `url` or `entity` parameters.

Fixes: https://github.com/AlexxIT/WebRTC/issues/88