### PR TITLE
Configuration flow uniqueness, YAML setup (with options)

### DIFF
--- a/custom_components/webrtc/__init__.py
+++ b/custom_components/webrtc/__init__.py
@@ -75,11 +75,6 @@ CONFIG_ENTRY_VALIDATOR: Final = vol.All(vol.Schema(
 ), max_less_or_equal_to_min)
 
 
-def ingest(value):
-    print(value)
-    return value
-
-
 CONFIG_SCHEMA: Final = vol.Schema(
     {
         vol.Optional(DOMAIN): CONFIG_ENTRY_VALIDATOR,

--- a/custom_components/webrtc/config_flow.py
+++ b/custom_components/webrtc/config_flow.py
@@ -4,18 +4,32 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigFlow, OptionsFlow, ConfigEntry
 from homeassistant.core import callback
 
-from . import DOMAIN, utils
+from . import CONFIG_ENTRY_VALIDATOR, CONF_UDP_MAX, CONF_UDP_MIN, DEFAULT_UDP_MAX, DEFAULT_UDP_MIN, \
+    DOMAIN, ZERO_PORT_VALIDATOR, utils
 
 
 class FlowHandler(ConfigFlow, domain=DOMAIN):
+    VERSION = 2
 
-    async def async_step_user(self, user_input=None):
+    async def async_create_config_entry(self, user_input):
+        await self.async_set_unique_id(DOMAIN)
+        self._abort_if_unique_id_configured()
+
         if utils.get_arch():
-            return self.async_create_entry(title="WebRTC Camera", data={})
+            return self.async_create_entry(title="WebRTC Camera", data={},
+                                           options=user_input)
 
         return self.async_abort(reason='arch', description_placeholders={
             'uname': str(platform.uname())
         })
+
+    async def async_step_user(self, user_input=None):
+        return await self.async_create_config_entry(CONFIG_ENTRY_VALIDATOR(user_input or {}))
+
+    async def async_step_import(self, user_input=None):
+        if not user_input:
+            return self.async_abort("user_input_empty")
+        return await self.async_create_config_entry(user_input)
 
     @staticmethod
     @callback
@@ -28,16 +42,29 @@ class OptionsFlowHandler(OptionsFlow):
         self.entry = entry
 
     async def async_step_init(self, user_input=None):
-        if user_input is not None:
-            return self.async_create_entry(title='', data=user_input)
+        errors = {}
+        if user_input:
+            udp_min, udp_max = user_input[CONF_UDP_MIN], user_input[CONF_UDP_MAX]
+            if udp_max != 0 and udp_min > udp_max:
+                errors[CONF_UDP_MIN] = "above_max"
 
-        udp_min = self.entry.options.get('udp_min', 0)
-        udp_max = self.entry.options.get('udp_max', 0)
+            if not errors:
+                return self.async_create_entry(title='', data=user_input)
+
+        if user_input:
+            user_input = {**self.entry.options, **user_input}
+        else:
+            user_input = self.entry.options
 
         return self.async_show_form(
             step_id="init",
             data_schema=vol.Schema({
-                vol.Optional('udp_min', default=udp_min): int,
-                vol.Optional('udp_max', default=udp_max): int
-            })
+                vol.Optional(CONF_UDP_MIN,
+                             default=user_input.get(
+                                 CONF_UDP_MIN) or DEFAULT_UDP_MIN): ZERO_PORT_VALIDATOR,
+                vol.Optional(CONF_UDP_MAX,
+                             default=user_input.get(
+                                 CONF_UDP_MAX) or DEFAULT_UDP_MAX): ZERO_PORT_VALIDATOR
+            }),
+            errors=errors,
         )

--- a/custom_components/webrtc/translations/en.json
+++ b/custom_components/webrtc/translations/en.json
@@ -1,11 +1,15 @@
 {
   "config": {
     "abort": {
-      "arch": "Unsupported OS architecture: {uname}"
+      "arch": "Unsupported OS architecture: {uname}",
+      "already_configured": "WebRTC is already configured"
     },
     "step": {}
   },
   "options": {
+    "errors": {
+      "above_max": "Value above max"
+    },
     "step": {
       "init": {
         "title": "WebRTC Camera Options",

--- a/custom_components/webrtc/translations/zh-Hant.json
+++ b/custom_components/webrtc/translations/zh-Hant.json
@@ -1,11 +1,15 @@
 {
   "config": {
     "abort": {
-      "arch": "\u4e0d\u652f\u63f4\u7684\u4f5c\u696d\u7cfb\u7d71\u67b6\u69cb: {uname}"
+      "arch": "\u4e0d\u652f\u63f4\u7684\u4f5c\u696d\u7cfb\u7d71\u67b6\u69cb: {uname}",
+      "already_configured": "WebRTC \u5df2\u7d93\u914d\u7f6e"
     },
     "step": {}
   },
   "options": {
+    "errors": {
+      "above_max": "\u9ad8\u65bc\u6700\u5927\u503c\u7684\u503c"
+    },
     "step": {
       "init": {
         "title": "WebRTC \u651d\u5f71\u6a5f\u9078\u9805",


### PR DESCRIPTION
- Added YAML configuration capability
- Enforced unique configurations between setups
- Enforced port number checking ((max > 0) ==> (max ≥ min))

At this current moment you can accidentally add two instances of WebRTC, may it be due to missing page refresh or else. This update enforces that such does not happen.

It also loads initial configuration from YAML (if provided) into options dictionary.