### PR TITLE
Update allow_cors key to allow_all_cors

### DIFF
--- a/custom_components/webrtc/utils.py
+++ b/custom_components/webrtc/utils.py
@@ -71,7 +71,7 @@ def register_static_path(app: web.Application, url_path: str, path):
         return web.FileResponse(path)
 
     route = app.router.add_route("GET", url_path, serve_file)
-    app['allow_cors'](route)
+    app['allow_all_cors'](route)
 
 
 async def init_resource(hass: HomeAssistantType, url: str, ver: str) -> bool:


### PR DESCRIPTION
The latest version is not compatible with HA 2021.12.0b0 because of https://github.com/home-assistant/core/pull/59360
This PR just change the naming that was updated in core from `allow_cors` to `allow_all_cors`
Fix #175