### PR TITLE
Remove background: black from ha-card style

### DIFF
--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -435,7 +435,6 @@ class WebRTCCamera extends HTMLElement {
                 width: 100%;
                 height: 100%;
                 position: relative;
-                background: black;
             }
             #video, .fix-safari {
                 width: 100%;


### PR DESCRIPTION
This CSS definition affects `ha-card`, which is a very common component in Lovelace.
In cases where the WebRTC component is embedded in another card (for example, entities card), it forces its black background styling on the **parent** `ha-card`, which has unintended consequences.
This PR will fix that bug.
