### PR TITLE
Add a home button for PTZ

### DIFF
--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -562,9 +562,13 @@ class WebRTCCamera extends HTMLElement {
                 transform: translateY(-50%);
             }
             .home {
-                left: 50%;
                 top: 50%;
-                transform: translate(-50%);
+                transform: translateY(-50%);
+                margin-left: auto;
+                margin-right: auto;
+                left: 0;
+                right: 0;
+                text-align: center;
             }
             .state {
                 right: 12px;

--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -524,6 +524,7 @@ class WebRTCCamera extends HTMLElement {
                 border-radius: 4px;
                 width: 40px;
                 height: 40px;
+                left: 20px;
             }
             .show {
                 display: block;

--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -509,7 +509,15 @@ class WebRTCCamera extends HTMLElement {
                 width: 80px;
                 height: 80px;
             }
-            .ptz-zoom, .ptz-home {
+            .ptz-zoom {
+                position: relative;
+                margin-top: 10px;
+                background-color: var( --ha-picture-card-background-color, rgba(0, 0, 0, 0.3) );
+                border-radius: 4px;
+                width: 80px;
+                height: 40px;
+            }
+            .ptz-home {
                 position: relative;
                 margin-top: 10px;
                 background-color: var( --ha-picture-card-background-color, rgba(0, 0, 0, 0.3) );
@@ -552,6 +560,11 @@ class WebRTCCamera extends HTMLElement {
                 right: 5px;
                 top: 50%;
                 transform: translateY(-50%);
+            }
+            .home {
+                left: 50%;
+                top: 50%;
+                transform: translate(-50%);
             }
             .state {
                 right: 12px;

--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -407,6 +407,14 @@ class WebRTCCamera extends HTMLElement {
             `;
             ptz.appendChild(ptzZoom);
         }
+        if (this.config.ptz.data_home) {
+            const ptzHome = document.createElement('div');
+            ptzHome.className = 'ptz-home';
+            ptzHome.innerHTML = `
+                <ha-icon class="home" icon="mdi:home"></ha-icon>
+            `;
+            ptz.appendChild(ptzHome);
+        }
         card.appendChild(ptz);
 
         const handlePTZ = (ev) => {
@@ -501,12 +509,12 @@ class WebRTCCamera extends HTMLElement {
                 width: 80px;
                 height: 80px;
             }
-            .ptz-zoom {
+            .ptz-zoom, .ptz-home {
                 position: relative;
                 margin-top: 10px;
                 background-color: var( --ha-picture-card-background-color, rgba(0, 0, 0, 0.3) );
                 border-radius: 4px;
-                width: 80px;
+                width: 40px;
                 height: 40px;
             }
             .show {


### PR DESCRIPTION
This is a reasonably simple PR that adds the ability to have a home button for PTZ, allowing the camera to return to the original location. This is done through a `data_home` section in the configuration.

For example, using ONVIF, I set a preset and then used the following config to add the button:
```yaml
data_home:
  entity_id: camera.up_driveway_mainstream
  preset: '1'
  move_mode: GotoPreset
```

The only thing that still remains to be done is updating the wiki to document this feature.

Here's what it looks like:
![image](https://user-images.githubusercontent.com/51303984/146634647-c09ec003-a901-415b-99d9-4be34f3dcc60.png)
