### PR TITLE
Add default border-radius to video

### DIFF
--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -454,6 +454,7 @@ class WebRTCCamera extends HTMLElement {
                 height: 100%;
                 display: block;
                 z-index: 0;
+                border-radius: var(--ha-card-border-radius, 4px);
             }
             .box {
                 position: absolute;


### PR DESCRIPTION
All blocks have initial border radius, but video show without border-radius.
This commit added default border radius.

Before:
![1](https://user-images.githubusercontent.com/2690324/161271598-acab8e64-ca10-4598-a9ff-7212e84697a1.jpg) ![2](https://user-images.githubusercontent.com/2690324/161271610-7ad5ed0e-92ec-4c24-8822-2c6820031f97.jpg)

After:
![1-result](https://user-images.githubusercontent.com/2690324/161271627-daea11f9-af2f-4ae5-bbe2-3d6aff36f117.jpg) ![2-result](https://user-images.githubusercontent.com/2690324/161271646-b5443fff-4f77-4f94-923c-d04a5dc08f6d.jpg)

