### PR TITLE
MSE: fix sign_path call for compatiblity with 2022.7

### DIFF
--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -62,14 +62,16 @@ class WebRTCCamera extends HTMLElement {
     async initMSE(hass, pc = null) {
         const ts = Date.now();
 
+        let unsignedPath = '/api/webrtc/ws?'
+        if (this.config.url) unsignedPath += '&url=' + encodeURIComponent(this.config.url);
+        if (this.config.entity) unsignedPath += '&entity=' + this.config.entity;
+
         const data = await hass.callWS({
             type: 'auth/sign_path',
-            path: '/api/webrtc/ws'
+            path: unsignedPath
         });
 
         let url = 'ws' + hass.hassUrl(data.path).substr(4);
-        if (this.config.url) url += '&url=' + encodeURIComponent(this.config.url);
-        if (this.config.entity) url += '&entity=' + this.config.entity;
 
         const video = this.querySelector('#video');
         const ws = this.ws = new WebSocket(url);

--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -64,7 +64,7 @@ class WebRTCCamera extends HTMLElement {
 
         let unsignedPath = '/api/webrtc/ws'
 
-        const needsParameterSigning = (this.hass.connection.haVersion >= '2022.7.0b0')
+        const needsParameterSigning = (hass.connection && hass.connection.haVersion >= '2022.7.0b0');
         if(needsParameterSigning) {
             unsignedPath += '?'
             if (this.config.url) unsignedPath += '&url=' + encodeURIComponent(this.config.url);

--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -62,9 +62,14 @@ class WebRTCCamera extends HTMLElement {
     async initMSE(hass, pc = null) {
         const ts = Date.now();
 
-        let unsignedPath = '/api/webrtc/ws?'
-        if (this.config.url) unsignedPath += '&url=' + encodeURIComponent(this.config.url);
-        if (this.config.entity) unsignedPath += '&entity=' + this.config.entity;
+        let unsignedPath = '/api/webrtc/ws'
+
+        const needsParameterSigning = (this.hass.connection.haVersion >= '2022.7.0b0')
+        if(needsParameterSigning) {
+            unsignedPath += '?'
+            if (this.config.url) unsignedPath += '&url=' + encodeURIComponent(this.config.url);
+            if (this.config.entity) unsignedPath += '&entity=' + this.config.entity;
+        }
 
         const data = await hass.callWS({
             type: 'auth/sign_path',
@@ -72,6 +77,10 @@ class WebRTCCamera extends HTMLElement {
         });
 
         let url = 'ws' + hass.hassUrl(data.path).substr(4);
+        if(!needsParameterSigning) {
+            if (this.config.url) url += '&url=' + encodeURIComponent(this.config.url);
+            if (this.config.entity) url += '&entity=' + this.config.entity;
+        }
 
         const video = this.querySelector('#video');
         const ws = this.ws = new WebSocket(url);


### PR DESCRIPTION
Since https://github.com/home-assistant/core/pull/73829 was merged, HA now requires that full path including the query parameters is signed.

Prior to this commit, the parameters were not included and this resulted in the websocket setup failures due to JWT token being invalid.

This commit resolves https://github.com/AlexxIT/WebRTC/issues/318 for me, although I have not tested this on any older HA instances as I don't have access to any.