### PR TITLE
Added new configuration variable to disable visiblity listener

### DIFF
--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -748,13 +748,15 @@ class WebRTCCamera extends HTMLElement {
             visibilityChange = "webkitvisibilitychange";
         }
 
-        document.addEventListener(visibilityChange, () => {
-            if (!document[hidden] && this.isConnected) {
-                this.connectedCallback();
-            } else {
-                this.disconnectedCallback();
-            }
-        }, false);
+        if(this.config.disable_visibility_listener != true) {
+            document.addEventListener(visibilityChange, () => {
+                if (!document[hidden] && this.isConnected) {
+                    this.connectedCallback();
+                } else {
+                    this.disconnectedCallback();
+                }
+            }, false);
+        }
     }
 
     async connectedCallback() {


### PR DESCRIPTION
This is important to make PIP (Picture in Picture) work
Probably the name of the variable is not the best, feel free to suggest something else.

Disabling this listener is important because as soon as you change TABS, the video is paused