### PR TITLE
Fix compatibility with python 3.11

### DIFF
--- a/custom_components/webrtc/__init__.py
+++ b/custom_components/webrtc/__init__.py
@@ -197,8 +197,8 @@ class WebSocketView(HomeAssistantView):
                 # Proxy requests
                 await asyncio.wait(
                     [
-                        _websocket_forward(ws_server, ws_client),
-                        _websocket_forward(ws_client, ws_server),
+                        asyncio.create_task(_websocket_forward(ws_server, ws_client)),
+                        asyncio.create_task(_websocket_forward(ws_client, ws_server)),
                     ],
                     return_when=asyncio.FIRST_COMPLETED,
                 )


### PR DESCRIPTION
asyncio.wait() now forbids coroutine parameters. Only tasks are allowed.

https://docs.python.org/3/library/asyncio-task.html#asyncio.wait

> Changed in version 3.11: Passing coroutine objects to wait() directly is forbidden.