### PR TITLE
"=" missing in dashboard resource URL

### DIFF
--- a/custom_components/webrtc/utils.py
+++ b/custom_components/webrtc/utils.py
@@ -137,6 +137,8 @@ async def init_resource(hass: HomeAssistant, url: str, ver: str) -> bool:
     await resources.async_get_info()
 
     url2 = f"{url}?{ver}"
+    if "v=" not in url2:
+        url2 = url2.replace("v","v=")
 
     for item in resources.async_items():
         if not item.get("url", "").startswith(url):


### PR DESCRIPTION
I had to manually add "=" to "/webrtc/webrtc-camera.js?v=3.1.0" to load the custom Home Assistant card. After that it was fine. 

Just putting this up as a suggestion. It's not pretty but it should work. I haven't tested it.