### PR TITLE
Add support for mouse down/up/long-click to ptz UI

### DIFF
--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -187,15 +187,15 @@ class WebRTCCamera extends VideoRTC {
         let hasZoom = false;
         let hasHome = false;
         for (const prefix of ['', '_start', '_end', '_long']) {
-            hasMove ||= this.config.ptz['data' + prefix + '_right'];
-            hasMove ||= this.config.ptz['data' + prefix + '_left'];
-            hasMove ||= this.config.ptz['data' + prefix + '_up'];
-            hasMove ||= this.config.ptz['data' + prefix + '_down'];
+            hasMove = hasMove || this.config.ptz['data' + prefix + '_right'];
+            hasMove = hasMove || this.config.ptz['data' + prefix + '_left'];
+            hasMove = hasMove || this.config.ptz['data' + prefix + '_up'];
+            hasMove = hasMove || this.config.ptz['data' + prefix + '_down'];
 
-            hasZoom ||= this.config.ptz['data' + prefix + '_zoom_in'];
-            hasZoom ||= this.config.ptz['data' + prefix + '_zoom_out'];
+            hasZoom = hasZoom || this.config.ptz['data' + prefix + '_zoom_in'];
+            hasZoom = hasZoom || this.config.ptz['data' + prefix + '_zoom_out'];
             
-            hasHome ||= this.config.ptz['data' + prefix + '_home'];
+            hasHome = hasHome || this.config.ptz['data' + prefix + '_home'];
         }
 
         const card = this.querySelector('.card');

--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -318,7 +318,7 @@ class WebRTCCamera extends VideoRTC {
                     if (endEvt.timeStamp - startEvt.timeStamp > 400) {
                         handle('long_' + className);
                     } else {
-                        handle(ev.target.className)
+                        handle(className);
                     }
                 }, { once: true });
             });

--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -1,6 +1,5 @@
 /** Chrome 63+, Safari 11.1+ */
 import {VideoRTC} from "./video-rtc.js?v=1.5.0";
-import {DigitalPTZ} from "./digital-ptz.js?v3.1.1"
 
 class WebRTCCamera extends VideoRTC {
     /**

--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -312,8 +312,10 @@ class WebRTCCamera extends VideoRTC {
         for (const [start, end] of [['touchstart', 'touchend'], ['mousedown', 'mouseup']]) {
             ptz.addEventListener(start, startEvt => {
                 const { className } = startEvt.target;
+                startEvt.preventDefault();
                 handle('start_' + className);
                 window.addEventListener(end, endEvt => {
+                    endEvt.preventDefault();
                     handle('end_' + className);
                     if (endEvt.timeStamp - startEvt.timeStamp > 400) {
                         handle('long_' + className);

--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -148,6 +148,7 @@ class WebRTCCamera extends VideoRTC {
                 background-color: black;
                 height: 100%;
                 position: relative; /* important for Safari */
+            }
             .header {
                 position: absolute;
                 top: 6px;


### PR DESCRIPTION
Camera apps typically treat ptz controls slightly different than this card: **movement starts on mouse down and ends on mouse up**
This PR allows for callbacks for each event independently, enabling this behaviour.
It also adds support for long press, which is useful to set the home preset.

Usage example:
```yaml
type: custom:webrtc-camera
url: camarablanca_dvrip
shortcuts:
  services:
    - name: Sync
      icon: mdi:clock-check
      service: icsee_ptz.synchronize_clock
      service_data:
        camera: garden
ptz:
  service: icsee_ptz.move
  data_home:
    camera: garden
    cmd: GotoPreset
    preset: 0
  data_long_home:
    camera: garden
    cmd: SetPreset
    preset: 0
  data_start_left:
    camera: garden
    cmd: DirectionLeft
    move_time: 10
  data_end_left:
    camera: garden
    cmd: DirectionLeft
    move_time: 0
  data_start_right:
    camera: garden
    cmd: DirectionRight
    move_time: 10
  data_end_right:
    camera: garden
    cmd: DirectionRight
    move_time: 0
  data_start_up:
    camera: garden
    cmd: DirectionUp
    move_time: 10
  data_end_up:
    camera: garden
    cmd: DirectionUp
    move_time: 0
  data_start_down:
    camera: garden
    cmd: DirectionDown
    move_time: 10
  data_end_down:
    camera: garden
    cmd: DirectionDown
    move_time: 0
```

Something similar can also be achieved with the onvif service using `move_mode: ContinuousMove`
