### PR TITLE
Adds fullscreen UI button for iOS

### DIFF
--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -489,6 +489,12 @@ class WebRTCCamera extends VideoRTC {
             this.exitFullscreen = () => document.webkitExitFullscreen();
             this.fullscreenElement = () => document.webkitFullscreenElement;
             this.fullscreenEvent = 'webkitfullscreenchange';
+        } else if (this.video.webkitEnterFullscreen) {
+            this.requestFullscreen = () => new Promise(resolve => {
+                this.video.webkitEnterFullscreen()
+                resolve()
+            })
+            this.exitFullscreen = () => video.webkitExitFullscreen();
         } else {
             this.querySelector('.fullscreen').style.display = 'none';
         }
@@ -542,10 +548,12 @@ class WebRTCCamera extends VideoRTC {
         });
 
         const fullscreen = this.querySelector('.fullscreen');
-        this.addEventListener(this.fullscreenEvent, () => {
-            fullscreen.icon = this.fullscreenElement()
-                ? 'mdi:fullscreen-exit' : 'mdi:fullscreen';
-        });
+        if (this.fullscreenEvent && this.fullscreenElement) {
+            this.addEventListener(this.fullscreenEvent, () => {
+                fullscreen.icon = this.fullscreenElement()
+                    ? 'mdi:fullscreen-exit' : 'mdi:fullscreen';
+            });
+        }
         const stream = this.querySelector('.stream');
         stream.style.display = this.config.streams.length > 1 ? 'block' : 'none';
     }


### PR DESCRIPTION
Fullscreen button was not showing on iOS since it does not support the `webkitRequestFullscreen` API.
However, we can still support full screen using `video.webkitEnterFullscreen`.
Using this API has the drawback of **not showing the custom UI overlay**, just the fullscreen video with the standard controls.

In my opinion, it is still a good option to be able to go fullscreen on iOS.

Fixes https://github.com/AlexxIT/WebRTC/issues/300.