### PR TITLE
Update go2rtc version to 1.8.4

### DIFF
--- a/custom_components/webrtc/utils.py
+++ b/custom_components/webrtc/utils.py
@@ -24,7 +24,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "webrtc"
 
-BINARY_VERSION = "1.8.1"
+BINARY_VERSION = "1.8.4"
 
 SYSTEM = {
     "Windows": {"AMD64": "go2rtc_win64.zip", "ARM64": "go2rtc_win_arm64.zip"},


### PR DESCRIPTION
Following previous commit, bumping bundled go2rtc version to latest

Example: https://github.com/AlexxIT/WebRTC/commit/c8ea6572636ae57d94cbf8fa4d27804c3f25d1ec