### PR TITLE
feat: refresh card based on IDLE or STREAMING state changes

### DIFF
--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -72,7 +72,7 @@ class WebRTCCamera extends VideoRTC {
 
         this.streamID = -1;
         this.nextStream(false);
-        setTimeout(() => this.checkStateChange(), 1000);
+        setTimeout(() => this.checkStateChange(), 2000);
     }
 
     checkStateChange() {
@@ -85,7 +85,7 @@ class WebRTCCamera extends VideoRTC {
             this.config.state = state
             this.nextStream(true);
         }
-        setTimeout(() => this.checkStateChange(), 1000);
+        setTimeout(() => this.checkStateChange(), 2000);
     }
 
     /**

--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -72,7 +72,7 @@ class WebRTCCamera extends VideoRTC {
 
         this.streamID = -1;
         this.nextStream(false);
-        setTimeout(() => this.checkStateChange(), 500);
+        setTimeout(() => this.checkStateChange(), 1000);
     }
 
     checkStateChange() {
@@ -85,7 +85,7 @@ class WebRTCCamera extends VideoRTC {
             this.config.state = state
             this.nextStream(true);
         }
-        setTimeout(() => this.checkStateChange(), 100);
+        setTimeout(() => this.checkStateChange(), 1000);
     }
 
     /**

--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -72,7 +72,7 @@ class WebRTCCamera extends VideoRTC {
 
         this.streamID = -1;
         this.nextStream(false);
-        setTimeout(() => this.checkStateChange(), 2000);
+        setTimeout(() => this.checkStateChange(), 1000);
     }
 
     checkStateChange() {
@@ -83,9 +83,10 @@ class WebRTCCamera extends VideoRTC {
         const state = this.hass.states[this.config.entity].state
         if (this.config.state != state) {
             this.config.state = state
-            this.nextStream(true);
+            if (this.config.state === "idle" || this.config.state === "streaming")
+                this.nextStream(true);
         }
-        setTimeout(() => this.checkStateChange(), 2000);
+        setTimeout(() => this.checkStateChange(), 1000);
     }
 
     /**

--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -71,7 +71,7 @@ class WebRTCCamera extends VideoRTC {
         this.streamID = -1;
         this.nextStream(false);
         if(this.config.entity)
-            setTimeout(() => this.checkStateChange(), 1000);
+            setTimeout(() => this.checkStateChange(), 2000);
     }
 
     checkStateChange() {
@@ -85,7 +85,7 @@ class WebRTCCamera extends VideoRTC {
             if (this.config.state === "idle" || this.config.state === "streaming")
                 this.nextStream(true);
         }
-        setTimeout(() => this.checkStateChange(), 1000);
+        setTimeout(() => this.checkStateChange(), 2000);
     }
 
     set hass(hass) {


### PR DESCRIPTION
There are some cameras out there which are only streaming intermittently, rather than continuously so WebRTC custom card waits for next reconnect (0 to 30 seconds).

With this PR, webrtc will be forced to refresh itself if the underlying camera entity's state changes into IDLE or STREAMING.

IDLE and STREAMING are defined in home assistant camera entity.

https://github.com/home-assistant/core/blob/dev/homeassistant/components/camera/__init__.py#L96

Looking forward to hearing your feedback.