### PR TITLE
Fix "takes 2 positional arguments but 3 were given"

### DIFF
--- a/custom_components/webrtc/utils.py
+++ b/custom_components/webrtc/utils.py
@@ -188,7 +188,7 @@ def dash_cast(hass: HomeAssistant, cast_entities: list, url: str, force=False):
                 entity._chromecast.register_handler(entity.dashcast)
 
             _LOGGER.debug(f"DashCast to {entity.entity_id}")
-            entity.dashcast.load_url(url, force)
+            entity.dashcast.load_url(url, force = force)
 
     except Exception:
         _LOGGER.exception(f"Can't DashCast to {cast_entities}")


### PR DESCRIPTION
This PR restore dash_cast functionality ith Chromecast devices and HA 2024.3.0 and fixes #664 