### PR TITLE
Added tap_action support

### DIFF
--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -260,8 +260,32 @@ class WebRTCCamera extends VideoRTC {
         const mode = this.querySelector('.mode');
         mode.addEventListener('click', () => this.nextStream(true));
 
+        const player = this.querySelector('.player');
+
+        // Tap action
+        player.addEventListener('click', e => {
+            if (this.config.tap_action && this.config.tap_action.action) {
+                this.handleAction("tap", this.config);
+                e.preventDefault();
+            }
+        });
+
         if (this.config.muted) this.video.muted = true;
         if (this.config.poster_remote) this.video.poster = this.config.poster;
+    }
+
+    handleAction(action, config) {
+        const event = new Event("hass-action", {
+            bubbles: true,
+            composed: true,
+          });
+
+          event.detail = {
+            config: config,
+            action: action
+          }
+
+          this.dispatchEvent(event);
     }
 
     renderDigitalPTZ() {


### PR DESCRIPTION
Added `tap_action` support using the below method:

https://developers.home-assistant.io/blog/2023/07/07/action-event-custom-cards/

I have not implemented `hold_action` or `double_tap_action` because they interfere with the video player and need more thorough investigation.