### PR TITLE
Add node_modules to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .idea/
 
 custom_components/webrtc/__pycache__/
+
+node_modules/


### PR DESCRIPTION
We really don’t want to commit the `node_modules` folder into the repo, so I’ve added it to the `.gitignore` file.