### PR TITLE
Update go2rtc version to 1.9.8

### DIFF
--- a/custom_components/webrtc/utils.py
+++ b/custom_components/webrtc/utils.py
@@ -25,7 +25,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "webrtc"
 
-BINARY_VERSION = "1.9.4"
+BINARY_VERSION = "1.9.8"
 
 SYSTEM = {
     "Windows": {"AMD64": "go2rtc_win64.zip", "ARM64": "go2rtc_win_arm64.zip"},


### PR DESCRIPTION
Following previous commit, bumping bundled go2rtc version to latest

https://github.com/AlexxIT/WebRTC/issues/788

