### PR TITLE
fix: use hass.data["lovelace"].resources instead of hass.data["lovela…

### DIFF
--- a/custom_components/webrtc/utils.py
+++ b/custom_components/webrtc/utils.py
@@ -126,7 +126,7 @@ async def init_resource(hass: HomeAssistant, url: str, ver: str) -> bool:
     random url to avoid problems with the cache. But chromecast don't support
     extra JS urls and can't load custom card.
     """
-    resources: ResourceStorageCollection = hass.data["lovelace"]["resources"]
+    resources: ResourceStorageCollection = hass.data["lovelace"].resources
     # force load storage
     await resources.async_get_info()
 


### PR DESCRIPTION
**Commit Message**

```
fix: use hass.data["lovelace"].resources instead of hass.data["lovelace"]["resources"]
```

**Extended Description**

This commit addresses the deprecation warning related to accessing Lovelace resources by dictionary key. As of Home Assistant 2026.2, direct dictionary access to lovelace_data['resources'] will no longer be supported, and the recommended approach is to use the property-based access lovelace_data.resources instead.

  

**Changes**

• Updated utils.py to replace:

```
resources: ResourceStorageCollection = hass.data["lovelace"]["resources"]
```

with:

```
resources: ResourceStorageCollection = hass.data["lovelace"].resources
```

  

• Ensured that references to resources in subsequent code remain compatible with the new property-based API.

  

By making this change, the WebRTC integration will remain functional in future Home Assistant releases past 2026.2.