### PR TITLE
Center Controls Icons/Text for Better Visualization

### DIFF
--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -471,6 +471,7 @@ class WebRTCCamera extends VideoRTC {
                     right: 5px;
                     bottom: 5px;
                     display: flex;
+                    align-items: center;
                 }
                 .space {
                     width: 100%;


### PR DESCRIPTION
Let it be known I am not a UI developer.  However, when using `ui: true` and having multiple streams, the HD/SD (or whatever you name it) text is misaligned. Let me know if there's more I should do to contribute to the repository. Thanks!

Before:
<img width="529" height="738" alt="image" src="https://github.com/user-attachments/assets/816109fb-599a-4b2c-810e-fb4932b94543" />


After
<img width="529" height="738" alt="image" src="https://github.com/user-attachments/assets/51af8e10-2bda-4081-aa05-b43980671d5d" />
