### PR TITLE
Fix iOS pinch-to-zoom initialization by listening to loadeddata event

### DIFF
--- a/custom_components/webrtc/www/digital-ptz.js
+++ b/custom_components/webrtc/www/digital-ptz.js
@@ -52,6 +52,7 @@ export class DigitalPTZ {
     if (o.touch_drag_pan) h.push(startTouchDragPan(gestureParam));
     if (o.touch_pinch_zoom) h.push(startTouchPinchZoom(gestureParam));
     this.videoEl.addEventListener("loadedmetadata", this.recomputeRects);
+    this.videoEl.addEventListener("loadeddata", this.recomputeRects);
     this.resizeObserver = new ResizeObserver(this.recomputeRects);
     this.resizeObserver.observe(this.containerEl);
     this.recomputeRects();
@@ -59,6 +60,7 @@ export class DigitalPTZ {
   destroy() {
     for (const off of this.offHandles) off();
     this.videoEl.removeEventListener("loadedmetadata", this.recomputeRects);
+    this.videoEl.removeEventListener("loadeddata", this.recomputeRects);
     this.resizeObserver.unobserve(this.containerEl);
   }
 }


### PR DESCRIPTION
On iOS Safari, the `<video>` element often reports `videoWidth`/`videoHeight` as `0` when only `loadedmetadata` has fired. This causes `DigitalPTZ.updateRects()` to bail early, leaving `this.videoRect` unset and breaking pinch-to-zoom until a later navigation or redraw.

This PR adds an additional listener for the `loadeddata` event, which reliably fires once the first frame is available and dimensions are known. With this change, `this.videoRect` is correctly initialized on iOS and pinch-to-zoom works immediately.

---

### **Changes**

* Add `videoEl.addEventListener("loadeddata", this.recomputeRects);` in `DigitalPTZ` constructor
* Ensures `this.videoRect` is set when the video dimensions are first available on iOS
