### PR TITLE
Added stream icon option

### DIFF
--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -129,6 +129,11 @@ class WebRTCCamera extends VideoRTC {
         return this.config.streams[this.streamID].name || `S${this.streamID}`;
     }
 
+    /** @return {string} */
+    get streamIcon() {
+        return this.config.streams[this.streamID].icon || `mdi:camera`;
+    }
+
     oninit() {
         super.oninit();
         this.renderMain();
@@ -480,13 +485,19 @@ class WebRTCCamera extends VideoRTC {
                     display: none;
                 }
                 .stream {
-                    padding-top: 2px;
+                    display: none;
+                    cursor: pointer;
+                    align-items: center;
+                }
+                .streamicon {
+                    pointer-events: none;
+                }
+                .streamname {
                     margin-left: 2px;
                     font-weight: 400;
                     font-size: 20px;
                     color: white;
-                    display: none;
-                    cursor: pointer;
+                    pointer-events: none;
                 }
             </style>
         `);
@@ -497,7 +508,10 @@ class WebRTCCamera extends VideoRTC {
                     <ha-icon class="fullscreen" icon="mdi:fullscreen"></ha-icon>
                     <ha-icon class="screenshot" icon="mdi:floppy"></ha-icon>
                     <ha-icon class="pictureinpicture" icon="mdi:picture-in-picture-bottom-right"></ha-icon>
-                    <span class="stream">${this.streamName}</span>
+                    <div class="stream">
+                        <ha-icon class="streamicon" icon="${this.streamIcon}"></ha-icon>
+                        <span class="streamname">${this.streamName}</span>
+                    </div>
                     <span class="space"></span>
                     <ha-icon class="play" icon="mdi:play"></ha-icon>
                     <ha-icon class="volume" icon="mdi:volume-high"></ha-icon>
@@ -563,7 +577,8 @@ class WebRTCCamera extends VideoRTC {
                 document.exitPictureInPicture().catch(console.warn);
             } else if (ev.target.className === 'stream') {
                 this.nextStream(true);
-                ev.target.innerText = this.streamName;
+                ev.target.querySelector('.streamname').innerText = this.streamName;
+                ev.target.querySelector('.streamicon').icon = this.streamIcon;
             }
         });
 
@@ -592,7 +607,7 @@ class WebRTCCamera extends VideoRTC {
         });
 
         const stream = this.querySelector('.stream');
-        stream.style.display = this.config.streams.length > 1 ? 'block' : 'none';
+        stream.style.display = this.config.streams.length > 1 ? 'flex' : 'none';
     }
 
     renderShortcuts() {


### PR DESCRIPTION
Added an option for an icon for different streams.

I have multiple streams to allow for toggleable two way audio. Previously I used emojis to represent when the mic was active or not, but this didn't fit well with the rest of the UI. The ideal would be to use a home-assistant icon.

The solution I propose is to add an icon next to the stream name. This can then be hidden if required by the style options. Similarly the name can be hidden leaving just the icon. By default, when no icon is specified, we default to the camera icon.

With no icon specified this looks like this:
<img width="507" height="297" alt="image" src="https://github.com/user-attachments/assets/a3bd6961-247e-4a2b-ac5e-d4996a66f14f" />

With this config:

```
 - type: custom:webrtc-camera
  streams:
    - entity: camera.nursery_camera
      media: video,audio
      icon: mdi:microphone-off
      name: Muted
    - entity: camera.nursery_camera
      media: video,audio,microphone
      icon: mdi:microphone
      name: Active
  ui: true
```

We get this result:
<img width="507" height="297" alt="image" src="https://github.com/user-attachments/assets/6c8b3ecd-63e6-45aa-b003-ddb0372b4194" />
and when you click on the stream:
<img width="507" height="297" alt="image" src="https://github.com/user-attachments/assets/f625b224-e36f-4ce7-89e8-0b77d262e054" />

Components can still be styled from the "stream" class (which is now a div).
Individual components can be hidden with "streamicon" or "streamname"
