### PR TITLE
fix(webrtc-camera.js): only change shortcuts.innerHTML on difference

### DIFF
--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -629,9 +629,13 @@ class WebRTCCamera extends VideoRTC {
         });
 
         this.renderTemplate('shortcuts', () => {
-            shortcuts.innerHTML = this.config.shortcuts.map((value, index) => `
+            const innerHTML = this.config.shortcuts.map((value, index) => `
                 <ha-icon data-index="${index}" icon="${value.icon}" title="${value.name}"></ha-icon>
             `).join('');
+
+            if (shortcuts.innerHTML !== innerHTML) {
+                shortcuts.innerHTML = innerHTML;
+            }
         });
     }
 


### PR DESCRIPTION
simple equality check of shortcuts innerHTML to avoid constant rewrites, causing loss of interaction events.
fixes https://github.com/AlexxIT/WebRTC/issues/795
