### PR TITLE
Add optional volume_entity for WebRTC media players

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,22 @@ media_player:
     audio: pcma
 ```
 
+If your camera integration exposes speaker volume as a Home Assistant `number`
+or `input_number` entity, you can attach it to the virtual media player:
+
+```yaml
+media_player:
+  - platform: webrtc
+    name: Tapo Camera
+    stream: tapo
+    audio: pcma
+    volume_entity: number.tapo_camera_speaker_volume
+```
+
+Home Assistant media players use `volume_level` values from `0` to `1`. The
+integration maps that range to the target entity's native `min` and `max`
+attributes, so a `number` with range `0..100` works as a percentage volume.
+
 ## FAQ
 
 **Q. Exernal access with WebRTC doesn't work**  

--- a/custom_components/webrtc/media_player.py
+++ b/custom_components/webrtc/media_player.py
@@ -9,10 +9,17 @@ from homeassistant.components.media_player import (
     MediaPlayerEntityFeature,
     PLATFORM_SCHEMA,
 )
-from homeassistant.const import STATE_PLAYING, STATE_IDLE, CONF_NAME
-from homeassistant.core import HomeAssistant
+from homeassistant.const import (
+    CONF_NAME,
+    STATE_IDLE,
+    STATE_PLAYING,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.typing import ConfigType
 
@@ -24,6 +31,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Required(CONF_NAME): cv.string,
         vol.Required("stream"): cv.string,
         vol.Required("audio"): cv.string,
+        vol.Optional("volume_entity"): cv.entity_id,
     },
     extra=vol.REMOVE_EXTRA,
 )
@@ -42,15 +50,80 @@ async def async_setup_platform(
 
 
 class WebRTCPlayer(MediaPlayerEntity):
-    def __init__(self, name: str, stream: str, audio: str, **kwargs):
+    def __init__(
+        self, name: str, stream: str, audio: str, volume_entity: str = None, **kwargs
+    ):
         self._attr_supported_features = (
             MediaPlayerEntityFeature.PLAY_MEDIA
             | MediaPlayerEntityFeature.BROWSE_MEDIA
             | MediaPlayerEntityFeature.STOP
         )
+        if volume_entity:
+            self._attr_supported_features |= MediaPlayerEntityFeature.VOLUME_SET
+
         self._attr_name = name
         self._attr_unique_id = stream
         self.audio = audio
+        self.volume_entity = volume_entity
+
+    async def async_added_to_hass(self) -> None:
+        if self.volume_entity:
+            self.async_on_remove(
+                async_track_state_change_event(
+                    self.hass, self.volume_entity, self._async_volume_state_changed
+                )
+            )
+
+    @callback
+    def _async_volume_state_changed(self, event) -> None:
+        self.async_write_ha_state()
+
+    @property
+    def volume_level(self) -> float | None:
+        if not self.volume_entity:
+            return None
+
+        state = self.hass.states.get(self.volume_entity)
+        if not state or state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+            return None
+
+        try:
+            value = float(state.state)
+            min_value = float(state.attributes.get("min", 0))
+            max_value = float(state.attributes.get("max", 100))
+        except (TypeError, ValueError):
+            return None
+
+        if max_value <= min_value:
+            return None
+
+        return min(1, max(0, (value - min_value) / (max_value - min_value)))
+
+    async def async_set_volume_level(self, volume: float) -> None:
+        if not self.volume_entity:
+            return
+
+        state = self.hass.states.get(self.volume_entity)
+        if not state:
+            return
+
+        try:
+            min_value = float(state.attributes.get("min", 0))
+            max_value = float(state.attributes.get("max", 100))
+        except (TypeError, ValueError):
+            min_value = 0
+            max_value = 100
+
+        volume = min(1, max(0, volume))
+        value = min_value + volume * (max_value - min_value)
+        domain = self.volume_entity.split(".", 1)[0]
+        await self.hass.services.async_call(
+            domain,
+            "set_value",
+            {"entity_id": self.volume_entity, "value": value},
+            blocking=True,
+        )
+        self.async_write_ha_state()
 
     async def async_play_media(self, media_type: str, media_id: str, **kwargs) -> None:
         if media_source.is_media_source_id(media_id):
@@ -90,7 +163,7 @@ class WebRTCPlayer(MediaPlayerEntity):
             resp = await r.json(content_type=None)
             playing = any("type" in p for p in resp["producers"])
             self._attr_state = STATE_PLAYING if playing else STATE_IDLE
-        except:
+        except Exception:
             pass
 
     async def async_browse_media(


### PR DESCRIPTION
## Summary
- add an optional `volume_entity` setting for WebRTC virtual media players
- expose `VOLUME_SET` and `volume_level` when a target volume entity is configured
- map Home Assistant media-player `volume_level` values (`0..1`) onto the target entity native `min`/`max` range before calling its `set_value` service
- update the media-player state when the target volume entity changes
- document using `volume_entity` with camera speaker volume `number`/`input_number` entities

## Why
Some two-way-audio camera integrations expose talk-back playback through WebRTC/go2rtc and speaker volume as a separate Home Assistant number entity. This lets users keep one media_player entity for playback and volume controls without camera-specific code in WebRTC.

## Validation
- `python3 -m ruff check custom_components/webrtc/media_player.py`
- `python3 -m compileall -q custom_components/webrtc/media_player.py`
- live-tested on Home Assistant 2026.5 with VIGI camera speaker volume numbers
- verified a `number` volume target with native range `0..100%` appears as media-player `volume_level=0.5`
- verified `media_player.volume_set` maps back to the VIGI number entity and restores from `0.4` to `0.5`
