### PR TITLE
Add optional push-to-talk mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,19 @@ streams:
     media: video,audio,microphone
 ```
 
+You can also enable push-to-talk. The microphone is captured only while the button is held, and
+the received camera audio is muted while talking to prevent echo:
+
+```yaml
+type: 'custom:webrtc-camera'
+url: doorbell
+media: video,audio,microphone
+ptt: true
+```
+
+The first press may ask for microphone permission and show `Microphone ready — hold again to talk`
+while the card reconnects. Microphone access requires HTTPS.
+
 **PS.** For Hass [Mobile App](https://www.home-assistant.io/integrations/mobile_app/) ensure that you can use microphone with the built-in [Assist](https://www.home-assistant.io/voice_control/).
 
 ## Snapshots to Telegram

--- a/README.md
+++ b/README.md
@@ -149,7 +149,6 @@ media: video,audio  # select only video or audio track, default both
 server: http://192.168.1.123:1984/     # custom go2rtc server address, default empty
 
 ui: true  # custom video controls, default false
-# when `media` includes `microphone`, the UI also shows a microphone mute button
 
 digital_ptz:  # digital zoom and pan via mouse/touch, defaults:
   mouse_drag_pan: true 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ media: video,audio  # select only video or audio track, default both
 server: http://192.168.1.123:1984/     # custom go2rtc server address, default empty
 
 ui: true  # custom video controls, default false
+# when `media` includes `microphone`, the UI also shows a microphone mute button
 
 digital_ptz:  # digital zoom and pan via mouse/touch, defaults:
   mouse_drag_pan: true 

--- a/custom_components/webrtc/manifest.json
+++ b/custom_components/webrtc/manifest.json
@@ -13,5 +13,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/AlexxIT/WebRTC/issues",
   "requirements": [],
-  "version": "v3.6.4"
+  "version": "v3.6.1"
 }

--- a/custom_components/webrtc/manifest.json
+++ b/custom_components/webrtc/manifest.json
@@ -13,5 +13,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/AlexxIT/WebRTC/issues",
   "requirements": [],
-  "version": "v3.6.2"
+  "version": "v3.6.4"
 }

--- a/custom_components/webrtc/manifest.json
+++ b/custom_components/webrtc/manifest.json
@@ -13,5 +13,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/AlexxIT/WebRTC/issues",
   "requirements": [],
-  "version": "v3.6.1"
+  "version": "v3.6.2"
 }

--- a/custom_components/webrtc/www/video-rtc.js
+++ b/custom_components/webrtc/www/video-rtc.js
@@ -45,6 +45,12 @@ export class VideoRTC extends HTMLElement {
         this.media = 'video,audio';
 
         /**
+         * [config] Current state of outgoing microphone tracks.
+         * @type {boolean}
+         */
+        this.microphoneMuted = false;
+
+        /**
          * [config] Run stream when not displayed on the screen. Default `false`.
          * @type {boolean}
          */
@@ -552,6 +558,7 @@ export class VideoRTC extends HTMLElement {
             if (this.media.includes('microphone')) {
                 const media = await navigator.mediaDevices.getUserMedia({audio: true});
                 media.getTracks().forEach(track => {
+                    track.enabled = !this.microphoneMuted;
                     pc.addTransceiver(track, {direction: 'sendonly'});
                 });
             }

--- a/custom_components/webrtc/www/video-rtc.js
+++ b/custom_components/webrtc/www/video-rtc.js
@@ -45,12 +45,6 @@ export class VideoRTC extends HTMLElement {
         this.media = 'video,audio';
 
         /**
-         * [config] Current state of outgoing microphone tracks.
-         * @type {boolean}
-         */
-        this.microphoneMuted = false;
-
-        /**
          * [config] Run stream when not displayed on the screen. Default `false`.
          * @type {boolean}
          */
@@ -558,7 +552,6 @@ export class VideoRTC extends HTMLElement {
             if (this.media.includes('microphone')) {
                 const media = await navigator.mediaDevices.getUserMedia({audio: true});
                 media.getTracks().forEach(track => {
-                    track.enabled = !this.microphoneMuted;
                     pc.addTransceiver(track, {direction: 'sendonly'});
                 });
             }

--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -118,6 +118,11 @@ class WebRTCCamera extends VideoRTC {
         this.mode = stream.mode || this.config.mode;
         this.media = stream.media || this.config.media;
 
+        const microphone = this.shadowRoot && this.shadowRoot.querySelector('.microphone');
+        if (microphone) {
+            microphone.style.display = this.media.includes('microphone') ? 'block' : 'none';
+        }
+
         if (reload) {
             this.ondisconnect();
             setTimeout(() => this.onconnect(), 100); // wait ws.close event
@@ -479,6 +484,9 @@ class WebRTCCamera extends VideoRTC {
                 .volume {
                     display: none;
                 }
+                .microphone {
+                    display: ${this.media.includes('microphone') ? 'block' : 'none'};
+                }
                 .stream {
                     padding-top: 2px;
                     margin-left: 2px;
@@ -500,6 +508,7 @@ class WebRTCCamera extends VideoRTC {
                     <span class="stream">${this.streamName}</span>
                     <span class="space"></span>
                     <ha-icon class="play" icon="mdi:play"></ha-icon>
+                    <ha-icon class="microphone" icon="mdi:microphone"></ha-icon>
                     <ha-icon class="volume" icon="mdi:volume-high"></ha-icon>
                 </div>
             </div>
@@ -551,6 +560,14 @@ class WebRTCCamera extends VideoRTC {
                 video.muted = false;
             } else if (icon === 'mdi:volume-high') {
                 video.muted = true;
+            } else if (icon === 'mdi:microphone' || icon === 'mdi:microphone-off') {
+                this.microphoneMuted = !this.microphoneMuted;
+                if (this.pc) {
+                    this.pc.getSenders()
+                        .filter(sender => sender.track && sender.track.kind === 'audio')
+                        .forEach(sender => sender.track.enabled = !this.microphoneMuted);
+                }
+                ev.target.icon = this.microphoneMuted ? 'mdi:microphone-off' : 'mdi:microphone';
             } else if (icon === 'mdi:fullscreen') {
                 this.requestFullscreen().catch(console.warn);
             } else if (icon === 'mdi:fullscreen-exit') {
@@ -693,4 +710,3 @@ const card = {
 // Apple iOS 12 doesn't support `||=`
 if (window.customCards) window.customCards.push(card);
 else window.customCards = [card];
-

--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -36,6 +36,7 @@ class WebRTCCamera extends VideoRTC {
          *     muted: boolean,
          *     intersection: number,
          *     ui: boolean,
+         *     ptt: boolean,
          *     style: string,
          *     background: boolean,
          *
@@ -62,7 +63,8 @@ class WebRTCCamera extends VideoRTC {
          * }} config
          */
         this.config = Object.assign({
-            mode: config.mse === false ? 'webrtc' : config.webrtc === false ? 'mse' : this.mode,
+            mode: config.ptt && !config.mode ? 'webrtc' :
+                config.mse === false ? 'webrtc' : config.webrtc === false ? 'mse' : this.mode,
             media: this.media,
             streams: [{url: config.url, entity: config.entity}],
             poster_remote: config.poster && (config.poster.indexOf('://') > 0 || config.poster.charAt(0) === '/'),
@@ -89,7 +91,7 @@ class WebRTCCamera extends VideoRTC {
      * Called by the Hass to calculate default card height.
      */
     getCardSize() {
-        return 5; // x 50px
+        return this.config.ptt ? 6 : 5; // x 50px
     }
 
     /**
@@ -132,6 +134,7 @@ class WebRTCCamera extends VideoRTC {
     oninit() {
         super.oninit();
         this.renderMain();
+        this.renderPTT();
         this.renderDigitalPTZ();
         this.renderPTZ();
         this.renderCustomUI();
@@ -208,6 +211,49 @@ class WebRTCCamera extends VideoRTC {
         }
     }
 
+    /**
+     * Avoid requesting microphone access during negotiation when push-to-talk is enabled.
+     * A track captured by the first button press is used once to negotiate an audio sender.
+     * @param pc {RTCPeerConnection}
+     * @return {Promise<RTCSessionDescriptionInit>}
+     */
+    async createOffer(pc) {
+        if (!this.config || !this.config.ptt || !this.media.includes('microphone')) {
+            return super.createOffer(pc);
+        }
+
+        const media = this.media;
+        const track = this.pttPendingTrack;
+        this.pttPendingTrack = null;
+        this.pttSender = null;
+
+        try {
+            if (track) {
+                this.pttSender = pc.addTransceiver(track, {direction: 'sendonly'}).sender;
+            }
+            this.media = media.split(',').filter(kind => kind !== 'microphone').join(',');
+            return await super.createOffer(pc);
+        } finally {
+            this.media = media;
+            if (track) {
+                try {
+                    if (this.pttSender) await this.pttSender.replaceTrack(null);
+                } finally {
+                    track.stop();
+                }
+            }
+        }
+    }
+
+    ondisconnect() {
+        if (this.pttTrack) this.pttTrack.stop();
+        if (this.pttPendingTrack) this.pttPendingTrack.stop();
+        this.pttTrack = null;
+        this.pttPendingTrack = null;
+        this.pttSender = null;
+        super.ondisconnect();
+    }
+
     renderMain() {
         const shadow = this.attachShadow({mode: 'open'});
         shadow.innerHTML = `
@@ -269,6 +315,135 @@ class WebRTCCamera extends VideoRTC {
 
         if (this.config.muted) this.video.muted = true;
         if (this.config.poster_remote) this.video.poster = this.config.poster;
+    }
+
+    renderPTT() {
+        if (!this.config.ptt || !this.media.includes('microphone')) return;
+
+        const card = this.querySelector('.card');
+        card.insertAdjacentHTML('beforebegin', `
+            <style>
+                .ptt {
+                    padding: 8px;
+                    background: var(--ha-card-background, var(--card-background-color, white));
+                    text-align: center;
+                }
+                .ptt-button {
+                    width: 100%;
+                    min-height: 44px;
+                    border: 0;
+                    border-radius: 4px;
+                    color: var(--primary-text-color);
+                    background: var(--secondary-background-color);
+                    font: inherit;
+                    touch-action: none;
+                    cursor: pointer;
+                    user-select: none;
+                    -webkit-user-select: none;
+                }
+                .ptt-button.active {
+                    color: white;
+                    background: var(--error-color, #db4437);
+                }
+                .ptt-message {
+                    min-height: 18px;
+                    margin-top: 4px;
+                    color: var(--secondary-text-color);
+                    font-size: 12px;
+                }
+                .ptt-message.error {
+                    color: var(--error-color, #db4437);
+                }
+            </style>
+        `);
+        card.insertAdjacentHTML('afterend', `
+            <div class="ptt">
+                <button class="ptt-button" type="button">Hold to talk</button>
+                <div class="ptt-message"></div>
+            </div>
+        `);
+
+        const button = this.querySelector('.ptt-button');
+        const message = this.querySelector('.ptt-message');
+
+        const resetPlayback = () => {
+            if (this.pttVideoMuted !== undefined) {
+                this.video.muted = this.pttVideoMuted;
+                this.pttVideoMuted = undefined;
+            }
+            button.classList.remove('active');
+            button.innerText = 'Hold to talk';
+        };
+
+        const stop = () => {
+            this.pttPressed = false;
+            const track = this.pttTrack;
+            this.pttTrack = null;
+            if (track) {
+                track.stop();
+                if (this.pttSender) this.pttSender.replaceTrack(null).catch(console.warn);
+            }
+            resetPlayback();
+        };
+
+        const errorText = error => {
+            if (!window.isSecureContext) return 'Microphone requires HTTPS';
+            if (error.name === 'NotAllowedError') return 'Microphone permission denied';
+            if (error.name === 'NotFoundError') return 'No microphone found';
+            return error.message || 'Unable to access microphone';
+        };
+
+        const start = async ev => {
+            ev.preventDefault();
+            if (this.pttPressed) return;
+
+            this.pttPressed = true;
+            this.pttVideoMuted = this.video.muted;
+            this.video.muted = true;
+            button.classList.add('active');
+            button.innerText = 'Talking...';
+            message.innerText = '';
+            message.classList.remove('error');
+
+            try {
+                const stream = await navigator.mediaDevices.getUserMedia({audio: true});
+                const track = stream.getAudioTracks()[0];
+                stream.getTracks().filter(value => value !== track).forEach(value => value.stop());
+                if (!track) throw new Error('No microphone track available');
+
+                if (!this.pttSender) {
+                    this.pttPressed = false;
+                    this.pttPendingTrack = track;
+                    message.innerText = 'Microphone ready — hold again to talk';
+                    resetPlayback();
+                    super.ondisconnect();
+                    setTimeout(() => this.onconnect(), 100);
+                    return;
+                }
+
+                if (!this.pttPressed) {
+                    track.stop();
+                    resetPlayback();
+                    return;
+                }
+
+                this.pttTrack = track;
+                await this.pttSender.replaceTrack(track);
+            } catch (error) {
+                this.pttPressed = false;
+                if (this.pttTrack) this.pttTrack.stop();
+                this.pttTrack = null;
+                message.innerText = errorText(error);
+                message.classList.add('error');
+                resetPlayback();
+            }
+        };
+
+        button.addEventListener('mousedown', start);
+        button.addEventListener('touchstart', start, {passive: false});
+        for (const event of ['mouseup', 'touchend', 'touchcancel', 'blur']) {
+            window.addEventListener(event, stop);
+        }
     }
 
     renderDigitalPTZ() {
@@ -693,4 +868,3 @@ const card = {
 // Apple iOS 12 doesn't support `||=`
 if (window.customCards) window.customCards.push(card);
 else window.customCards = [card];
-

--- a/custom_components/webrtc/www/webrtc-camera.js
+++ b/custom_components/webrtc/www/webrtc-camera.js
@@ -118,11 +118,6 @@ class WebRTCCamera extends VideoRTC {
         this.mode = stream.mode || this.config.mode;
         this.media = stream.media || this.config.media;
 
-        const microphone = this.shadowRoot && this.shadowRoot.querySelector('.microphone');
-        if (microphone) {
-            microphone.style.display = this.media.includes('microphone') ? 'block' : 'none';
-        }
-
         if (reload) {
             this.ondisconnect();
             setTimeout(() => this.onconnect(), 100); // wait ws.close event
@@ -484,9 +479,6 @@ class WebRTCCamera extends VideoRTC {
                 .volume {
                     display: none;
                 }
-                .microphone {
-                    display: ${this.media.includes('microphone') ? 'block' : 'none'};
-                }
                 .stream {
                     padding-top: 2px;
                     margin-left: 2px;
@@ -508,7 +500,6 @@ class WebRTCCamera extends VideoRTC {
                     <span class="stream">${this.streamName}</span>
                     <span class="space"></span>
                     <ha-icon class="play" icon="mdi:play"></ha-icon>
-                    <ha-icon class="microphone" icon="mdi:microphone"></ha-icon>
                     <ha-icon class="volume" icon="mdi:volume-high"></ha-icon>
                 </div>
             </div>
@@ -560,14 +551,6 @@ class WebRTCCamera extends VideoRTC {
                 video.muted = false;
             } else if (icon === 'mdi:volume-high') {
                 video.muted = true;
-            } else if (icon === 'mdi:microphone' || icon === 'mdi:microphone-off') {
-                this.microphoneMuted = !this.microphoneMuted;
-                if (this.pc) {
-                    this.pc.getSenders()
-                        .filter(sender => sender.track && sender.track.kind === 'audio')
-                        .forEach(sender => sender.track.enabled = !this.microphoneMuted);
-                }
-                ev.target.icon = this.microphoneMuted ? 'mdi:microphone-off' : 'mdi:microphone';
             } else if (icon === 'mdi:fullscreen') {
                 this.requestFullscreen().catch(console.warn);
             } else if (icon === 'mdi:fullscreen-exit') {
@@ -710,3 +693,4 @@ const card = {
 // Apple iOS 12 doesn't support `||=`
 if (window.customCards) window.customCards.push(card);
 else window.customCards = [card];
+


### PR DESCRIPTION
## Summary

Adds an opt-in push-to-talk mode:

```yaml
type: custom:webrtc-camera
url: doorbell
media: video,audio,microphone
ptt: true
```

- renders a Hold to talk button below the video
- captures and transmits the microphone only while the button is held
- detaches and stops the microphone track while idle
- mutes received camera audio while talking to prevent delayed echo
- requests microphone access from the button gesture for iOS/WebKit compatibility
- grants permission and negotiates an audio sender on the first hold, then shows Microphone ready — hold again to talk
- displays HTTPS, permission, device, and capture errors on the card
- defaults PTT cards to WebRTC mode unless a mode is explicitly configured

The implementation is contained in webrtc-camera.js; the vendored video-rtc.js is unchanged.